### PR TITLE
Remove wrong standards

### DIFF
--- a/rulesets/.php_cs.dist
+++ b/rulesets/.php_cs.dist
@@ -6,6 +6,7 @@ return PhpCsFixer\Config::create()
         '@Symfony'                   => true,
         '@Symfony:risky'             => true,
         'binary_operator_spaces'     => ['align_double_arrow' => true],
+        'concat_space'               => ['spacing' => 'one'],
         'array_syntax'               => ['syntax' => 'short'],
         'combine_consecutive_unsets' => true,
         // one should use PHPUnit methods to set up expected exception instead of annotations
@@ -24,6 +25,7 @@ return PhpCsFixer\Config::create()
         'semicolon_after_instruction'           => true,
         'strict_comparison'                     => true,
         'strict_param'                          => false,
+        'phpdoc_summary'                        => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/rulesets/phpcs.xml
+++ b/rulesets/phpcs.xml
@@ -31,7 +31,6 @@
             <property name="ignoreBlankLines" value="false"/>
         </properties>
     </rule>
-    <rule ref="Generic.Formatting.MultipleStatementAlignment"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
         <type>error</type>
     </rule>


### PR DESCRIPTION
- Remove `MultipleStatementAlignment` from phpcs xml
- Remove the dots at the end of the phpdoc for php cs fixer