### PR TITLE
Checker: Remove unit tests

### DIFF
--- a/bin/checker
+++ b/bin/checker
@@ -146,10 +146,6 @@ else
         node_modules/.bin/eslint $FILES_JS --ext js,vue
         [ $? -ne 0 ] && let "ERROR_COUNT++"
     fi
-
-    command "Unit Tests"
-    node_modules/.bin/karma start app/karma.conf.js.dist --single-run
-    [ $? -ne 0 ] && let "ERROR_COUNT++"
 fi
 
 if [ $ERROR_COUNT -ne 0 ] ;


### PR DESCRIPTION
- unit tests shouldn't be part of checker,
because it requires assets to be installed and configured

Related [ch443]