### PR TITLE
PHPMD: exclude ExcessivePublicCount, TooManyFields, TooManyPublicMethods

### DIFF
--- a/rulesets/pmd.xml
+++ b/rulesets/pmd.xml
@@ -13,7 +13,10 @@
     <rule ref="rulesets/controversial.xml" />
 
     <rule ref="rulesets/codesize.xml">
+        <exclude name="ExcessivePublicCount" />
+        <exclude name="TooManyFields" />
         <exclude name="TooManyMethods" />
+        <exclude name="TooManyPublicMethods" />
         <exclude name="CyclomaticComplexity" />
         <exclude name="ExcessiveParameterList" />
     </rule>


### PR DESCRIPTION
OROCRM entity classes have many public methods and many fields.
For now it is better exclude those rules from checks, but keep in mind
as best practice, when writing new classes.

Examples:

- The class DispoArticle has 45 public methods and attributes.
Consider reducing the number of public items to less than 45.

- The class DispoArticle has 20 fields. Consider redesigning
DispoArticle to keep the number of fields under 15.

- The class OroUser has 13 public methods. Consider refactoring
OroUser to keep number of public methods under 10.

Related [ch36]