### PR TITLE
PHPCS: exclude rule MemberVarContainsNumbers

### DIFF
--- a/rulesets/phpcs.xml
+++ b/rulesets/phpcs.xml
@@ -14,6 +14,9 @@
     <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
         <type>error</type>
     </rule>
+    <rule ref="Zend.NamingConventions.ValidVariableName.MemberVarContainsNumbers">
+        <severity>0</severity>
+    </rule>
     <rule ref="Symfony.Commenting.License">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
We have in code variables like `street2`, `$iso2Code`, `$iso3Code`.
So I think it is better to leave those variable as is and just remove this rule.

Found in [coma](https://github.com/banovo/coma/pull/122).

Related [ch645]