### PR TITLE
PHPMD: exclude rule CouplingBetweenObjects

### DIFF
--- a/rulesets/pmd.xml
+++ b/rulesets/pmd.xml
@@ -43,7 +43,9 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"><priority>1</priority></rule>
 
 
-    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/design.xml">
+        <exclude name="CouplingBetweenObjects" />
+    </rule>
 
     <rule ref="rulesets/naming.xml">
         <exclude name="LongVariable" />


### PR DESCRIPTION
Coma project has this problem:
src/AppBundle/Entity/AppCustomerProject.php:32 The class
AppCustomerProject has a coupling between objects value of 13.
Consider to reduce the number of dependencies under 13.

We can't really change this entity to reduce coupling.

Related [ch645]