### PR TITLE
remove phpcpd

### DIFF
--- a/bin/checker
+++ b/bin/checker
@@ -189,14 +189,6 @@ else
     [ $? -ne 0 ] && let "ERROR_COUNT++"
     success "Coding Standards check completed"
 
-    if [ -n "$FILES_PHP_FILTERED" ];
-    then
-        command "Copy/Paste Detector"
-        $BINDIR/phpcpd $FILES_PHP_FILTERED
-        [ $? -ne 0 ] && let "ERROR_COUNT++"
-        success "Copy/Paste Detector check completed"
-    fi
-
     command "Mess Detector"
     for f in $FILES_PHP
     do

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,9 @@
     "keywords": ["Banovo", "coding standard", "phpcs"],
     "homepage": "https://github.com/banovo/coding-standard",
     "license": "MIT",
-    "minimum-stability": "dev",
     "require": {
         "squizlabs/php_codesniffer": "3.*",
-        "sebastian/phpcpd": "6.0.2",
+        "sebastian/phpcpd": "^6.0",
         "phpmd/phpmd": "2.9.1",
         "friendsofphp/php-cs-fixer": "2.15.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "license": "MIT",
     "require": {
         "squizlabs/php_codesniffer": "3.*",
-        "sebastian/phpcpd": "^6.0",
         "phpmd/phpmd": "2.9.1",
         "friendsofphp/php-cs-fixer": "2.15.8"
     },


### PR DESCRIPTION
phpcpd is causing phpunit to fail:

```
PHPUnit 9.0.1 by Sebastian Bergmann and contributors.

Testing 
Non-static method SebastianBergmann\Timer\Timer::start() should not be called statically
```

as a next step will be to use coding-standards checker as standalone tool, not included as project dependency so we can include phpcpd back